### PR TITLE
Add React Native mobile app

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,12 @@
+import { StatusBar } from 'expo-status-bar';
+import { Slot } from 'expo-router';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+export default function App() {
+  return (
+    <SafeAreaProvider>
+      <StatusBar style="light" />
+      <Slot />
+    </SafeAreaProvider>
+  );
+}

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,22 @@
+# PES Teacher Mobile
+
+This directory contains a basic React Native app built with Expo. The app mirrors the existing web portal's login flow and styling. It uses the same Supabase backend so credentials and environment variables remain consistent.
+
+## Setup
+
+1. Install dependencies from the `mobile` folder:
+
+   ```bash
+   cd mobile
+   npm install
+   ```
+
+2. Define `EXPO_PUBLIC_SUPABASE_URL` and `EXPO_PUBLIC_SUPABASE_ANON_KEY` in a `.env` file or through your environment.
+
+3. Start the development server:
+
+   ```bash
+   npm start
+   ```
+
+This opens the Expo DevTools where you can run the app on an emulator or a physical device.

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,27 @@
+{
+  "expo": {
+    "name": "PES Teacher Mobile",
+    "slug": "pes-teacher-mobile",
+    "version": "1.0.0",
+    "sdkVersion": "50.0.0",
+    "platforms": ["ios", "android"],
+    "orientation": "portrait",
+    "jsEngine": "hermes",
+    "userInterfaceStyle": "automatic",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "assetBundlePatterns": ["**/*"],
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "foregroundImage": "./assets/adaptive-icon.png",
+        "backgroundColor": "#FFFFFF"
+      }
+    }
+  }
+}

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function Layout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/mobile/app/dashboard.tsx
+++ b/mobile/app/dashboard.tsx
@@ -1,0 +1,2 @@
+import DashboardScreen from '../screens/DashboardScreen';
+export default DashboardScreen;

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -1,0 +1,2 @@
+import LoginScreen from '../screens/LoginScreen';
+export default LoginScreen;

--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,3 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+registerRootComponent(App);

--- a/mobile/lib/supabase.ts
+++ b/mobile/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL || '';
+const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || '';
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -1,0 +1,2 @@
+const { getDefaultConfig } = require('expo/metro-config');
+module.exports = getDefaultConfig(__dirname);

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "pes-teacher-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "expo-status-bar": "^2.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-native": "0.73.0",
+    "react-native-safe-area-context": "^4.8.0",
+    "react-native-web": "^0.19.9",
+    "@supabase/supabase-js": "^2.49.4",
+    "expo-router": "^2.4.0"
+  }
+}

--- a/mobile/screens/DashboardScreen.tsx
+++ b/mobile/screens/DashboardScreen.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { supabase } from '../lib/supabase';
+import { useRouter } from 'expo-router';
+
+export default function DashboardScreen() {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    router.replace('/');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Welcome</Text>
+      <TouchableOpacity onPress={handleLogout} style={styles.button}>
+        <Text style={styles.buttonText}>Logout</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#1a1a1a',
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    color: '#fff',
+    marginBottom: 24,
+  },
+  button: {
+    backgroundColor: '#fff',
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 24,
+  },
+  buttonText: {
+    color: '#000',
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+});

--- a/mobile/screens/LoginScreen.tsx
+++ b/mobile/screens/LoginScreen.tsx
@@ -1,0 +1,104 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, Image, KeyboardAvoidingView } from 'react-native';
+import { supabase } from '../lib/supabase';
+import { useRouter } from 'expo-router';
+
+export default function LoginScreen() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [status, setStatus] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    (async () => {
+      const { data: { user }, error } = await supabase.auth.getUser();
+      if (user && !error) {
+        router.replace('/dashboard');
+      }
+    })();
+  }, []);
+
+  const handleLogin = async () => {
+    setStatus('Logging in...');
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      setStatus('Login failed: ' + error.message);
+    } else {
+      setStatus('Success!');
+      router.replace('/dashboard');
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView style={styles.container} behavior="padding">
+      <View style={styles.panel}>
+        <Text style={styles.title}>Faculty Sign in</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Email"
+          placeholderTextColor="#555"
+          value={email}
+          onChangeText={setEmail}
+        />
+        <TextInput
+          style={styles.input}
+          secureTextEntry
+          placeholder="Password"
+          placeholderTextColor="#555"
+          value={password}
+          onChangeText={setPassword}
+        />
+        <TouchableOpacity style={styles.button} onPress={handleLogin}>
+          <Text style={styles.buttonText}>Log In</Text>
+        </TouchableOpacity>
+        {status ? <Text style={styles.status}>{status}</Text> : null}
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  panel: {
+    backgroundColor: '#fff',
+    padding: 24,
+    width: '80%',
+    borderRadius: 24,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#000',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  input: {
+    backgroundColor: '#eee',
+    marginBottom: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    color: '#000',
+  },
+  button: {
+    backgroundColor: '#fdba74',
+    paddingVertical: 12,
+    borderRadius: 24,
+    alignItems: 'center',
+  },
+  buttonText: {
+    fontWeight: 'bold',
+    color: '#000',
+    fontSize: 16,
+  },
+  status: {
+    marginTop: 8,
+    textAlign: 'center',
+    color: '#555',
+  },
+});


### PR DESCRIPTION
## Summary
- add new `mobile/` directory with an Expo React Native project
- implement login and dashboard screens that match existing styling
- document setup steps for running the mobile app

## Testing
- `npm install`
- `npm run lint` *(fails: multiple lint errors in existing app code)*

------
https://chatgpt.com/codex/tasks/task_e_6841b485a940833197a2cf6b7ed970a4