### PR TITLE
Make CSV controls appear as buttons

### DIFF
--- a/app/questions/page.tsx
+++ b/app/questions/page.tsx
@@ -576,13 +576,12 @@ export default function QuestionManagementPage() {
                                     type="file"
                                     accept=".csv"
                                     onChange={handleCSVUpload}
-                                    className="block text-sm text-white file:mr-4 file:py-2 file:px-4 file:border-0
-                     file:text-sm file:font-semibold file:bg-white file:text-black rounded"
+                                    className="block text-sm text-white file:mr-4 file:py-2 file:px-4 file:border-0 file:text-sm file:font-semibold file:bg-black file:text-white rounded"
                                 />
                                 <button
                                     type="button"
                                     onClick={handleSampleDownload}
-                                    className="mt-2 text-blue-400 underline text-sm"
+                                    className="mt-2 px-4 py-2 bg-black text-white rounded"
                                 >
                                     Download sample CSV
                                 </button>


### PR DESCRIPTION
## Summary
- style the file input and download sample buttons in the Add Question modal

## Testing
- `npm ci`
- `npx next lint` *(fails: numerous lint errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_6843ccb2c01c83319d26aef174b7031f