### PR TITLE
Add logo to auth pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect } from 'react'
 import { supabase } from '@/lib/supabase'
 import Image from 'next/image'
 import vrDoctorsImg from '@/public/login-side.png' // Replace with your actual path
+import caveLogo from '@/public/cave-logo1.png'
 import { useRouter } from 'next/navigation'
 
 
@@ -99,8 +100,9 @@ export default function LoginPage() {
                     </form>
                 </div>
 
-                <div className="absolute top-6 left-9 text-white font-bold text-2xl tracking-wide">
-                    PESU Simulation Suite
+                <div className="absolute top-6 left-6 flex items-center text-white font-bold text-2xl tracking-wide">
+                    <Image src={caveLogo} alt="PESU logo" width={40} height={40} className="mr-2" />
+                    <span>PESU Simulation Suite</span>
                 </div>
             </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -102,7 +102,7 @@ export default function LoginPage() {
 
                 <div className="absolute top-6 left-6 flex items-center text-white font-bold text-2xl tracking-wide">
                     <Image src={caveLogo} alt="PESU logo" width={200} height={200} className="mr-2" />
-                    <span>PESU Simulation Suite</span>
+                    
                 </div>
             </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -101,7 +101,7 @@ export default function LoginPage() {
                 </div>
 
                 <div className="absolute top-6 left-6 flex items-center text-white font-bold text-2xl tracking-wide">
-                    <Image src={caveLogo} alt="PESU logo" width={40} height={40} className="mr-2" />
+                    <Image src={caveLogo} alt="PESU logo" width={200} height={200} className="mr-2" />
                     <span>PESU Simulation Suite</span>
                 </div>
             </div>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -70,7 +70,7 @@ export default function SignupPage() {
                     className="rounded-r-none"
                 />
                 <div className="absolute top-6 left-6 flex items-center text-white font-bold text-2xl tracking-wide">
-                    <Image src={caveLogo} alt="PESU logo" width={40} height={40} className="mr-2" />
+                    <Image src={caveLogo} alt="PESU logo" width={200} height={200} className="mr-2" />
                     <span>PESU Simulation Suite</span>
                 </div>
             </div>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -71,7 +71,7 @@ export default function SignupPage() {
                 />
                 <div className="absolute top-6 left-6 flex items-center text-white font-bold text-2xl tracking-wide">
                     <Image src={caveLogo} alt="PESU logo" width={200} height={200} className="mr-2" />
-                    <span>PESU Simulation Suite</span>
+                    
                 </div>
             </div>
 

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect } from 'react'
 import { supabase } from '@/lib/supabase'
 import Image from 'next/image'
 import vrDoctorsImg from '@/public/building-logo.png'
+import caveLogo from '@/public/cave-logo1.png'
 import { useRouter } from 'next/navigation'
 
 const schema = z.object({
@@ -68,8 +69,9 @@ export default function SignupPage() {
                     objectFit="cover"
                     className="rounded-r-none"
                 />
-                <div className="absolute top-6 left-6 text-white font-bold text-2xl tracking-wide">
-                    PESU Simulation Suite
+                <div className="absolute top-6 left-6 flex items-center text-white font-bold text-2xl tracking-wide">
+                    <Image src={caveLogo} alt="PESU logo" width={40} height={40} className="mr-2" />
+                    <span>PESU Simulation Suite</span>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- display `cave-logo1.png` beside the "PESU Simulation Suite" heading on login and signup pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443fb6a2b083319dc5413fc5d3c3ca