### PR TITLE
Show admin link for admin users

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
+import { allowedAdmins } from '@/lib/constants'
 import Image from 'next/image'
 import logo from '@/public/cave-logo1.png'
 import nav from '@/public/nav-logo.png'
@@ -18,7 +19,6 @@ interface Procedure {
 
 export default function AdminProceduresPage() {
   const router = useRouter()
-  const allowedAdmins = ['pes2202100762@pesu.pes.edu'] // Add more emails as needed
 
   const [authorized, setAuthorized] = useState(false)
   const [checked, setChecked] = useState(false)

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from 'react-markdown'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
+import { allowedAdmins } from '@/lib/constants'
 import nav from '@/public/nav-logo.png'
 import logo from '@/public/cave-logo1.png'
 //import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, LineChart, Line, CartesianGrid, Legend } from 'recharts'
@@ -38,6 +39,7 @@ interface Procedure {
 
 export default function ClassAnalyticsPage() {
     const router = useRouter()
+    const [isAdmin, setIsAdmin] = useState(false)
     const [semester, setSemester] = useState('')
     const [section, setSection] = useState('')
     const [sections, setSections] = useState<string[]>([])
@@ -57,7 +59,10 @@ export default function ClassAnalyticsPage() {
         (async () => {
             const { data: { user } } = await supabase.auth.getUser()
             if (!user) router.push('/')
-            else setTeacherName(user.user_metadata?.name || 'Unknown Teacher')
+            else {
+                setTeacherName(user.user_metadata?.name || 'Unknown Teacher')
+                setIsAdmin(allowedAdmins.includes(user.email ?? ''))
+            }
         })()
     }, [])
 
@@ -533,6 +538,9 @@ export default function ClassAnalyticsPage() {
                             <button onClick={() => router.push('/classcreate')} className="text-left w-full">Bulk Creation</button>
                             <button onClick={() => router.push('/analytics')} className="text-left w-full bg-gray-200 text-black rounded px-1 py-1">Analytics</button>
                             <button onClick={() => router.push('/questions')}className="text-left w-full">Manage Questions</button>
+                            {isAdmin && (
+                                <button onClick={() => router.push('/admin')} className="text-left w-full">Admin</button>
+                            )}
                             <button onClick={() => router.push('/myaccount')} className="text-left w-full">My Account</button>
                         </nav>
                         <button onClick={async () => { await supabase.auth.signOut(); router.push('/') }} className="text-left text-lg mt-10">Logout</button>

--- a/app/classcreate/page.tsx
+++ b/app/classcreate/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
+import { allowedAdmins } from '@/lib/constants'
 import nav from '@/public/nav-logo.png'
 import logo from '@/public/cave-logo1.png'
 import headerWave from '@/public/header-removebg-preview.png'
@@ -24,6 +25,7 @@ interface Procedure {
 
 export default function SessionsPage() {
     const router = useRouter()
+    const [isAdmin, setIsAdmin] = useState(false)
     const [semester, setSemester] = useState('')
     const [section, setSection] = useState('')
     const [sections, setSections] = useState<string[]>([])
@@ -40,6 +42,7 @@ export default function SessionsPage() {
         (async () => {
             const { data: { user }, error: userErr } = await supabase.auth.getUser()
             if (userErr || !user) { router.push('/'); return }
+            setIsAdmin(allowedAdmins.includes(user.email ?? ''))
         })()
     }, [router])
 
@@ -173,6 +176,9 @@ export default function SessionsPage() {
                         <button onClick={() => router.push('/classcreate')} className="text-left w-full bg-gray-200 text-black rounded px-1 py-1">Bulk Creation</button>
                         <button onClick={() => router.push('/analytics')} className="text-left w-full">Analytics</button>
                         <button onClick={() => router.push('/questions')}className="text-left w-full">Manage Questions</button>
+                        {isAdmin && (
+                            <button onClick={() => router.push('/admin')} className="text-left w-full">Admin</button>
+                        )}
                         <button onClick={() => router.push('/myaccount')} className="text-left w-full">My Account</button>
                     </nav>
                     <button onClick={handleLogout} className="text-left text-lg mt-10">Logout</button>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,6 +4,7 @@
 import {JSX, useEffect, useState} from 'react'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
+import { allowedAdmins } from '@/lib/constants'
 import dynamic from 'next/dynamic'
 import Image from 'next/image'
 import logo from '@/public/cave-logo1.png'
@@ -34,6 +35,7 @@ export default function DashboardPage() {
     const router = useRouter()
 
     const [teacherName, setTeacherName] = useState('')
+    const [isAdmin, setIsAdmin] = useState(false)
     const [srn, setSrn] = useState('')
     const [procedureId, setProcedureId] = useState('')
     const [mode, setMode] = useState<'practice' | 'evaluation'>('practice')
@@ -49,6 +51,7 @@ export default function DashboardPage() {
             const { data: { user }, error: userErr } = await supabase.auth.getUser()
             if (userErr || !user) { router.push('/'); return }
             setTeacherName(user.user_metadata?.name ?? 'Teacher')
+            setIsAdmin(allowedAdmins.includes(user.email ?? ''))
 
             const { data: procList } = await supabase.from('procedures').select('id, procedure_name, package_name')
             setProcedures(procList as Procedure[] ?? [])
@@ -257,6 +260,9 @@ export default function DashboardPage() {
                             <button onClick={() => router.push('/classcreate')} className="text-left w-full">Bulk Creation</button>
                             <button onClick={() => router.push('/analytics')} className="text-left w-full">Analytics</button>
                             <button onClick={() => router.push('/questions')}className="text-left w-full">Manage Questions</button>
+                            {isAdmin && (
+                                <button onClick={() => router.push('/admin')} className="text-left w-full">Admin</button>
+                            )}
                             <button onClick={() => router.push('/myaccount')} className="text-left w-full">My Account</button>
                         </nav>
                         <button onClick={handleLogout} className="text-left text-lg mt-10">Logout</button>

--- a/app/myaccount/page.tsx
+++ b/app/myaccount/page.tsx
@@ -4,12 +4,14 @@ import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
+import { allowedAdmins } from '@/lib/constants'
 import nav from '@/public/nav-logo.png'
 import logo from '@/public/cave-logo1.png'
 import headerWave from '@/public/header-removebg-preview.png'
 
 export default function AccountPage() {
   const router = useRouter()
+  const [isAdmin, setIsAdmin] = useState(false)
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [status, setStatus] = useState('')
@@ -22,6 +24,7 @@ export default function AccountPage() {
       } else {
         setName(user.user_metadata?.name || '')
         setEmail(user.email || '')
+        setIsAdmin(allowedAdmins.includes(user.email ?? ''))
       }
     })()
   }, [router])
@@ -55,6 +58,9 @@ export default function AccountPage() {
             <button onClick={() => router.push('/classcreate')} className="text-left w-full">Bulk Creation</button>
             <button onClick={() => router.push('/analytics')} className="text-left w-full">Analytics</button>
             <button onClick={() => router.push('/questions')}className="text-left w-full">Manage Questions</button>
+            {isAdmin && (
+            <button onClick={() => router.push('/admin')} className="text-left w-full">Admin</button>
+            )}
             <button onClick={() => router.push('/myaccount')} className="text-left w-full bg-gray-200 text-black rounded px-1 py-1">My Account</button>
           </nav>
           <button onClick={handleLogout} className="text-left text-lg mt-10">Logout</button>

--- a/app/questions/page.tsx
+++ b/app/questions/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
+import { allowedAdmins } from '@/lib/constants';
 import Image from 'next/image';
 import logo from '@/public/cave-logo1.png';
 import nav from '@/public/nav-logo.png';
@@ -26,6 +27,7 @@ interface Question {
 
 export default function QuestionManagementPage() {
     const router = useRouter();
+    const [isAdmin, setIsAdmin] = useState(false);
     const [teacherName, setTeacherName] = useState('');
     const [procedures, setProcedures] = useState<Procedure[]>([]);
     const [selectedProcedure, setSelectedProcedure] = useState<Procedure | null>(null);
@@ -46,6 +48,7 @@ export default function QuestionManagementPage() {
             const { data: { user }, error } = await supabase.auth.getUser();
             if (!user || error) return router.push('/');
             setTeacherName(user.user_metadata?.name ?? 'Teacher');
+            setIsAdmin(allowedAdmins.includes(user.email ?? ''));
 
             const { data } = await supabase
                 .from('procedures')
@@ -370,6 +373,9 @@ export default function QuestionManagementPage() {
                     <button onClick={() => router.push('/classcreate')} className="text-left w-full">Bulk Creation</button>
                     <button onClick={() => router.push('/analytics')} className="text-left w-full">Analytics</button>
                     <button onClick={() => router.push('/questions')}className="text-left w-full bg-gray-200 text-black rounded px-2 py-1">Manage Questions</button>
+                    {isAdmin && (
+                        <button onClick={() => router.push('/admin')} className="text-left w-full">Admin</button>
+                    )}
                     <button onClick={() => router.push('/myaccount')} className="text-left w-full">My Account</button>
                 </nav>
                 <button onClick={async () => { await supabase.auth.signOut(); router.push('/') }} className="text-left text-lg mt-10">Logout</button>

--- a/app/sessions/page.tsx
+++ b/app/sessions/page.tsx
@@ -4,6 +4,7 @@ import {JSX, useEffect, useState} from 'react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
+import { allowedAdmins } from '@/lib/constants'
 import nav from '@/public/nav-logo.png'
 import logo from '@/public/cave-logo1.png'
 import headerWave from '@/public/header-removebg-preview.png'
@@ -27,6 +28,7 @@ interface LogRow {
 
 export default function SessionsPage() {
     const router = useRouter()
+    const [isAdmin, setIsAdmin] = useState(false)
     const [semester, setSemester] = useState('')
     const [section, setSection] = useState('')
     const [sections, setSections] = useState<string[]>([])
@@ -48,6 +50,7 @@ export default function SessionsPage() {
         (async () => {
             const { data: { user }, error: userErr } = await supabase.auth.getUser()
             if (userErr || !user) { router.push('/'); return }
+            setIsAdmin(allowedAdmins.includes(user.email ?? ''))
         })()
     }, [router])
 
@@ -252,6 +255,9 @@ export default function SessionsPage() {
                             <button onClick={() => router.push('/classcreate')} className="text-left w-full">Bulk Creation</button>
                             <button onClick={() => router.push('/analytics')} className="text-left w-full">Analytics</button>
                             <button onClick={() => router.push('/questions')}className="text-left w-full">Manage Questions</button>
+                            {isAdmin && (
+                                <button onClick={() => router.push('/admin')} className="text-left w-full">Admin</button>
+                            )}
                             <button onClick={() => router.push('/myaccount')} className="text-left w-full">My Account</button>
                         </nav>
                         <button onClick={handleLogout} className="text-left text-lg mt-10">Logout</button>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,1 @@
+export const allowedAdmins = ['pes2202100762@pesu.pes.edu'];


### PR DESCRIPTION
## Summary
- add `allowedAdmins` list
- show admin button in sidebar navigation when the logged-in user is an allowed admin
- read allowed admin list in admin page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845896ccee08331ae7385ef8af70529