### PR TITLE
Add admin user management

### DIFF
--- a/app/api/admin-users/route.ts
+++ b/app/api/admin-users/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import nodemailer from 'nodemailer'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+export async function GET() {
+  const { data, error } = await supabase.auth.admin.listUsers()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ users: data.users })
+}
+
+export async function POST(req: NextRequest) {
+  const { action, id, email } = await req.json()
+  try {
+    if (!action || !id) {
+      return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
+    }
+    if (action === 'ban') {
+      const { error } = await supabase.auth.admin.updateUserById(id, { ban_duration: '8760h' })
+      if (error) throw error
+    } else if (action === 'unban') {
+      const { error } = await supabase.auth.admin.updateUserById(id, { ban_duration: 'none' })
+      if (error) throw error
+    } else if (action === 'delete') {
+      const { error } = await supabase.auth.admin.deleteUser(id)
+      if (error) throw error
+    } else if (action === 'resetPassword') {
+      if (!email) return NextResponse.json({ error: 'Email required' }, { status: 400 })
+      const { data, error } = await supabase.auth.admin.generateLink({
+        type: 'recovery',
+        email
+      })
+      if (error) throw error
+      const link = data?.properties?.action_link || data?.action_link
+      if (link) {
+        const transporter = nodemailer.createTransport({
+          service: 'gmail',
+          auth: {
+            user: process.env.GMAIL_USER!,
+            pass: process.env.GMAIL_PASS!
+          }
+        })
+        await transporter.sendMail({
+          from: process.env.GMAIL_USER!,
+          to: email,
+          subject: 'Password Reset',
+          text: `Reset your password using the following link: ${link}`
+        })
+      }
+    } else {
+      return NextResponse.json({ error: 'Invalid action' }, { status: 400 })
+    }
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message }, { status: 500 })
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dayjs": "^1.11.13",
         "html2pdf.js": "^0.10.3",
         "next": "15.3.1",
+        "nodemailer": "^6.9.9",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.56.1",
@@ -6046,6 +6047,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-markdown": "^10.1.0",
     "recharts": "^2.15.3",
     "uuid": "^11.1.0",
-    "zod": "^3.24.3"
+    "zod": "^3.24.3",
+    "nodemailer": "^6.9.9"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- allow admins to manage users in admin page
- add API route for user management actions
- install nodemailer for sending reset emails

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68464f88b4948331911bc89fc18546dd