### PR TITLE
Add attendance and recent logins widgets

### DIFF
--- a/app/api/recent-logins/route.ts
+++ b/app/api/recent-logins/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+export async function GET(_req: NextRequest) {
+  try {
+    const { data, error } = await supabase.auth.admin.listUsers({ perPage: 50 })
+    if (error) {
+      console.error(error)
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+    const users = (data.users || [])
+      .filter((u) => u.last_sign_in_at)
+      .sort(
+        (a, b) =>
+          new Date(b.last_sign_in_at as string).getTime() -
+          new Date(a.last_sign_in_at as string).getTime()
+      )
+      .slice(0, 10)
+      .map((u) => ({ email: u.email, last_sign_in_at: u.last_sign_in_at }))
+    return NextResponse.json({ users })
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json({ error: 'Failed to fetch logins' }, { status: 500 })
+  }
+}

--- a/app/api/recent-logins/route.ts
+++ b/app/api/recent-logins/route.ts
@@ -1,12 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
+import { NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-)
-
-export async function GET(_req: NextRequest) {
+export async function GET() {
   try {
     const { data, error } = await supabase.auth.admin.listUsers({ perPage: 50 })
     if (error) {

--- a/app/dashboard/AttendanceChart.tsx
+++ b/app/dashboard/AttendanceChart.tsx
@@ -1,0 +1,75 @@
+'use client'
+import {
+  LineChart as ReLineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+
+interface DayStat {
+  date: string
+  count: number
+}
+
+export default function AttendanceChart() {
+  const [data, setData] = useState<DayStat[]>([])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const start = new Date()
+      start.setDate(start.getDate() - 6)
+      const { data: logs, error } = await supabase
+        .from('logs')
+        .select('created_at')
+        .gte('created_at', start.toISOString())
+      if (error) {
+        console.error('Failed to fetch attendance', error)
+        return
+      }
+      const counts: Record<string, number> = {}
+      for (let i = 0; i < 7; i++) {
+        const d = new Date()
+        d.setDate(d.getDate() - i)
+        counts[formatDate(d)] = 0
+      }
+      ;(logs || []).forEach((l) => {
+        const date = formatDate(new Date(l.created_at))
+        if (counts[date] !== undefined) counts[date]++
+      })
+      const arr = Object.entries(counts)
+        .sort(([a], [b]) => parseDate(a).getTime() - parseDate(b).getTime())
+        .map(([date, count]) => ({ date, count }))
+      setData(arr)
+    }
+    fetchData()
+  }, [])
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <ReLineChart data={data} margin={{ top: 20, right: 30, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="4 4" stroke="#555" />
+        <XAxis dataKey="date" stroke="#ccc" />
+        <YAxis stroke="#ccc" />
+        <Tooltip contentStyle={{ backgroundColor: '#222', border: 'none' }} />
+        <Line type="monotone" dataKey="count" stroke="#22c55e" strokeWidth={3} dot={{ stroke: '#22c55e', strokeWidth: 2, r: 4 }} activeDot={{ r: 6 }} />
+      </ReLineChart>
+    </ResponsiveContainer>
+  )
+}
+
+function formatDate(d: Date) {
+  const day = String(d.getDate()).padStart(2, '0')
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const year = String(d.getFullYear()).slice(-2)
+  return `${day}-${month}-${year}`
+}
+
+function parseDate(s: string) {
+  const [day, month, year] = s.split('-').map(Number)
+  return new Date(2000 + year, month - 1, day)
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ import nav from '@/public/nav-logo.png'
 import headerWave from '@/public/header-removebg-preview.png'
 
 const LineChart = dynamic(() => import('./LineChart'), { ssr: false })
+const AttendanceChart = dynamic(() => import('./AttendanceChart'), { ssr: false })
 
 interface Procedure {
     id: string
@@ -30,6 +31,10 @@ interface SessionWithProcedure {
     procedures: { procedure_name: string; package_name: string }
 }
 interface LogRow { result: any }
+interface LoginInfo {
+    email: string | null
+    last_sign_in_at: string | null
+}
 
 export default function DashboardPage() {
     const router = useRouter()
@@ -45,6 +50,7 @@ export default function DashboardPage() {
     const [status, setStatus] = useState('')
     const [showModal, setShowModal] = useState(false)
     const [selectedLog, setSelectedLog] = useState<LogRow | null>(null)
+    const [recentLogins, setRecentLogins] = useState<LoginInfo[]>([])
 
     useEffect(() => {
         (async () => {
@@ -83,6 +89,16 @@ export default function DashboardPage() {
                 logs[s.session_code] = !!row
             }
             setLogAvailability(logs)
+
+            try {
+                const res = await fetch('/api/recent-logins')
+                if (res.ok) {
+                    const json = await res.json()
+                    setRecentLogins(json.users)
+                }
+            } catch (err) {
+                console.error('Failed to fetch recent logins', err)
+            }
         })()
     }, [router])
 
@@ -302,6 +318,27 @@ export default function DashboardPage() {
                                     <LineChart />
                                 </div>
                             </div>
+                        </section>
+                    </div>
+
+                    <div className="flex gap-10">
+                        <section className="bg-[#3a3a3a] p-6 rounded-2xl w-1/2 relative">
+                            <h3 className="text-2xl font-bold mb-4">Attendance</h3>
+                            <div className="h-48 rounded overflow-hidden">
+                                <AttendanceChart />
+                            </div>
+                        </section>
+
+                        <section className="bg-[#2a2a2a] p-6 rounded-2xl w-1/2">
+                            <h3 className="text-2xl font-bold mb-4">Recent Logins</h3>
+                            <ul className="space-y-2 text-sm">
+                                {recentLogins.map((l, idx) => (
+                                    <li key={idx} className="flex justify-between border-b border-gray-700 pb-1">
+                                        <span>{l.email ?? 'Unknown'}</span>
+                                        <span>{l.last_sign_in_at ? new Date(l.last_sign_in_at).toLocaleString('en-IN', { timeZone: 'Asia/Kolkata' }) : '-'}</span>
+                                    </li>
+                                ))}
+                            </ul>
                         </section>
                     </div>
 


### PR DESCRIPTION
## Summary
- show recent faculty login data via new API endpoint
- chart student attendance from `logs` table
- display both widgets on the dashboard

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684acb5bdb0083319d6022f2dbaa1c33